### PR TITLE
Skip duplicate memory files by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,27 +368,27 @@ If no selectors are specified, all memory files are included.
 
 ### Deduplicating Memories
 
-When you have multiple memory files with overlapping content, you can use the `name` attribute in the frontmatter to deduplicate them. The name should be in `PascalCase` format, like `CodingStandards`, `TestPractices`, `CodeComments`, `Logging`, or `ErrorHandling`. If two memory files have the same `name`, only the first one found will be included in the context.
+When you have multiple memory files with the same filename (basename), only the first one encountered will be included. This allows you to override default memories with project-specific ones by using the same filename.
 
 **Example:**
 
-`memory1.md`:
+If you have two directories with memory files:
+
+`~/.coding-context/memories/general/setup.md`:
 ```markdown
 ---
-name: MyMemory
 ---
-This is a memory.
+This is the default setup memory.
 ```
 
-`memory2.md`:
+`./memories/setup.md`:
 ```markdown
 ---
-name: MyMemory
 ---
-This is another memory with the same name.
+This is a project-specific setup memory.
 ```
 
-When the tool processes these two files, it will include only one of them (either `memory1.md` or `memory2.md`) and exclude the other, since they have the same name. **Which file is included depends on the order in which files are encountered during filesystem traversal, which is not guaranteed to be alphabetical or consistent.** You should not rely on which specific file is included when duplicates exist. This mechanism is useful for overriding default memories with project-specific ones, but for deterministic behavior, ensure memory names are unique.
+When the tool processes these two files, it will include only one of them based on which is encountered first during filesystem traversal. **The order depends on the order of memory paths specified and filesystem traversal order, which is not guaranteed to be alphabetical or consistent.** This mechanism is useful for overriding default memories with project-specific ones when you use the same filename.
 
 
 ## Output Files

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func run(ctx context.Context, args []string) error {
 		}
 	}
 
-	memoryNames := make(map[string]bool)
+	memoryBasenames := make(map[string]bool)
 
 	for _, memory := range memories {
 
@@ -211,13 +211,13 @@ func run(ctx context.Context, args []string) error {
 				return nil
 			}
 
-			if name, ok := frontmatter["name"]; ok {
-				if memoryNames[name] {
-					fmt.Fprintf(os.Stdout, "Excluding memory file (other memory with same name found): %s\n", path)
-					return nil
-				}
-				memoryNames[name] = true
+			// Check for duplicate basenames
+			basename := filepath.Base(path)
+			if memoryBasenames[basename] {
+				fmt.Fprintf(os.Stdout, "Excluding memory file (other memory with same basename found): %s\n", path)
+				return nil
 			}
+			memoryBasenames[basename] = true
 
 			// Estimate tokens for this file
 			tokens := estimateTokens(content)

--- a/memory_name_test.go
+++ b/memory_name_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,40 +10,48 @@ import (
 
 func TestMemoryNameExclusion(t *testing.T) {
 	// Create a temporary directory for our test files
-	tmpDir, err := ioutil.TempDir("", "memory-name-test")
+	tmpDir, err := os.MkdirTemp("", "memory-name-test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Create two memory files with the same name in their frontmatter
-	name: MyMemory
+	// Create two subdirectories with memory files with the same basename
+	dir1 := filepath.Join(tmpDir, "dir1")
+	dir2 := filepath.Join(tmpDir, "dir2")
+	if err := os.MkdirAll(dir1, 0755); err != nil {
+		t.Fatalf("Failed to create dir1: %v", err)
+	}
+	if err := os.MkdirAll(dir2, 0755); err != nil {
+		t.Fatalf("Failed to create dir2: %v", err)
+	}
+
+	memory1Content := `---
 ---
 This is the first memory.`
-	memory1Path := filepath.Join(tmpDir, "memory1.md")
-	if err := ioutil.WriteFile(memory1Path, []byte(memory1Content), 0644); err != nil {
-		t.Fatalf("Failed to write memory1.md: %v", err)
+	memory1Path := filepath.Join(dir1, "memory.md")
+	if err := os.WriteFile(memory1Path, []byte(memory1Content), 0644); err != nil {
+		t.Fatalf("Failed to write memory.md in dir1: %v", err)
 	}
 
 	memory2Content := `---
-name: MyMemory
 ---
 This is the second memory.`
-	memory2Path := filepath.Join(tmpDir, "memory2.md")
-	if err := ioutil.WriteFile(memory2Path, []byte(memory2Content), 0644); err != nil {
-		t.Fatalf("Failed to write memory2.md: %v", err)
+	memory2Path := filepath.Join(dir2, "memory.md")
+	if err := os.WriteFile(memory2Path, []byte(memory2Content), 0644); err != nil {
+		t.Fatalf("Failed to write memory.md in dir2: %v", err)
 	}
 
 	// Create a dummy task file
 	taskContent := "This is the task."
 	taskPath := filepath.Join(tmpDir, "task.md")
-	if err := ioutil.WriteFile(taskPath, []byte(taskContent), 0644); err != nil {
+	if err := os.WriteFile(taskPath, []byte(taskContent), 0644); err != nil {
 		t.Fatalf("Failed to write task.md: %v", err)
 	}
 
 	// Set up the arguments for the run function
 	args := []string{"task"}
-	memories = []string{tmpDir}
+	memories = []string{dir1, dir2}
 	tasks = []string{tmpDir}
 	outputDir = tmpDir
 	params = make(paramMap)
@@ -59,15 +66,16 @@ This is the second memory.`
 	}
 
 	// Check the output
-	promptBytes, err := ioutil.ReadFile(filepath.Join(tmpDir, "prompt.md"))
+	promptBytes, err := os.ReadFile(filepath.Join(tmpDir, "prompt.md"))
 	if err != nil {
 		t.Fatalf("Failed to read prompt.md: %v", err)
 	}
 	prompt := string(promptBytes)
 
 	// We expect only one of the memories to be included
-	if !(strings.Contains(prompt, "This is the first memory.") && !strings.Contains(prompt, "This is the second memory.")) &&
-		!(!strings.Contains(prompt, "This is the first memory.") && strings.Contains(prompt, "This is the second memory.")) {
+	hasFirst := strings.Contains(prompt, "This is the first memory.")
+	hasSecond := strings.Contains(prompt, "This is the second memory.")
+	if hasFirst == hasSecond {
 		t.Errorf("Expected only one memory to be included, but got: %s", prompt)
 	}
 }


### PR DESCRIPTION
Track memory names from frontmatter and exclude subsequent files that share the same name. Print a message when a file is skipped.