### PR TITLE
feat: relax skill name/description length limits in lenient mode

### DIFF
--- a/pkg/codingcontext/context.go
+++ b/pkg/codingcontext/context.go
@@ -1088,17 +1088,15 @@ func (cc *Context) validateAndAddSkill(frontmatter markdown.SkillFrontMatter, sk
 	const maxSkillNameLen = 64
 	if len(frontmatter.Name) > maxSkillNameLen {
 		if lenient {
-			cc.logger.Warn("skipping skill: name exceeds maximum length", "path", skillFile, "length", len(frontmatter.Name))
-
-			return nil
+			cc.logger.Warn("skill name exceeds maximum length", "path", skillFile, "length", len(frontmatter.Name))
 		} else if cc.lintMode {
 			cc.lintCollector.recordError(skillFile, LintErrorKindSkillValidation,
 				fmt.Sprintf("%v: %s (got %d)", ErrSkillNameLength, skillFile, len(frontmatter.Name)))
 
 			return nil
+		} else {
+			return fmt.Errorf("%w: %s (got %d)", ErrSkillNameLength, skillFile, len(frontmatter.Name))
 		}
-
-		return fmt.Errorf("%w: %s (got %d)", ErrSkillNameLength, skillFile, len(frontmatter.Name))
 	}
 
 	if frontmatter.Description == "" {
@@ -1118,14 +1116,16 @@ func (cc *Context) validateAndAddSkill(frontmatter markdown.SkillFrontMatter, sk
 
 	const maxSkillDescLen = 1024
 	if len(frontmatter.Description) > maxSkillDescLen {
-		if cc.lintMode {
+		if lenient {
+			cc.logger.Warn("skill description exceeds maximum length", "path", skillFile, "length", len(frontmatter.Description))
+		} else if cc.lintMode {
 			cc.lintCollector.recordError(skillFile, LintErrorKindSkillValidation,
 				fmt.Sprintf("%v: %s (got %d)", ErrSkillDescriptionLength, skillFile, len(frontmatter.Description)))
 
 			return nil
+		} else {
+			return fmt.Errorf("%w: %s (got %d)", ErrSkillDescriptionLength, skillFile, len(frontmatter.Description))
 		}
-
-		return fmt.Errorf("%w: %s (got %d)", ErrSkillDescriptionLength, skillFile, len(frontmatter.Description))
 	}
 
 	absPath, err := filepath.Abs(skillFile)

--- a/pkg/codingcontext/context_test.go
+++ b/pkg/codingcontext/context_test.go
@@ -2795,7 +2795,7 @@ name: no-desc-skill
 			},
 		},
 		{
-			name: "lenient: skip skill when name exceeds max length",
+			name: "lenient: include skill when name exceeds max length",
 			setup: func(t *testing.T, strictDir, lenientDir string) {
 				t.Helper()
 				createTask(t, strictDir, "test-task", "", "Test task content")
@@ -2812,8 +2812,39 @@ description: Valid description
 			wantErr:  false,
 			checkFunc: func(t *testing.T, result *Result) {
 				t.Helper()
-				if len(result.Skills.Skills) != 0 {
-					t.Errorf("expected 0 skills (skipped due to name too long), got %d", len(result.Skills.Skills))
+				if len(result.Skills.Skills) != 1 {
+					t.Fatalf("expected 1 skill (lenient mode allows oversized name), got %d", len(result.Skills.Skills))
+				}
+				wantName := "this-is-a-very-long-skill-name-that-exceeds-the-maximum-allowed-length-of-64-characters"
+				if result.Skills.Skills[0].Name != wantName {
+					t.Errorf("expected skill name %q, got %q", wantName, result.Skills.Skills[0].Name)
+				}
+			},
+		},
+		{
+			name: "lenient: include skill when description exceeds max length",
+			setup: func(t *testing.T, strictDir, lenientDir string) {
+				t.Helper()
+				createTask(t, strictDir, "test-task", "", "Test task content")
+
+				longDesc := strings.Repeat("a", 1025)
+				createSkill(t, lenientDir, filepath.Join(".agents", "skills", "long-desc-skill"), fmt.Sprintf(`---
+name: long-desc-skill
+description: %s
+---
+
+# Long Desc Skill
+`, longDesc))
+			},
+			taskName: "test-task",
+			wantErr:  false,
+			checkFunc: func(t *testing.T, result *Result) {
+				t.Helper()
+				if len(result.Skills.Skills) != 1 {
+					t.Fatalf("expected 1 skill (lenient mode allows oversized description), got %d", len(result.Skills.Skills))
+				}
+				if got := len(result.Skills.Skills[0].Description); got != 1025 {
+					t.Errorf("expected description length 1025, got %d", got)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
  - Lenient mode now warns and **includes** skills whose `name` exceeds 64 chars or `description` exceeds 1024 chars, instead of skipping or erroring.
  - Strict mode and lint mode are unchanged: oversized fields still error / record a lint error as before.
  - Adds two `TestLenientSearchPaths` cases covering the new behavior; updates the existing oversized-name case from "skip" to "include."

## Motivation
Lenient paths are meant to include third-party skills on a best-effort basis. A description nudging past 1024 bytes (easy to hit with multi-byte UTF-8) shouldn't drop the skill entirely — a warning is enough.